### PR TITLE
File mode should be a string in puppet4

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,7 +12,7 @@ define phpmyadmin::install($version = $title, $installdir)
 			ensure => directory,
 			owner  => root,
 			group  => root,
-			mode   => 0755,
+			mode   => '0755',
 		}
 	}
 	# Creating source directory
@@ -43,7 +43,7 @@ define phpmyadmin::install($version = $title, $installdir)
 		ensure => directory,
 		owner  => root,
 		group  => root,
-		mode   => 0755,
+		mode   => '0755',
 	}
 	exec {'copy-phpmyadmin':
 		command => "cp -Rf ${phpmyadmin::params::srcdir}/phpMyAdmin-${version}-all-languages ${phpmyadmin::params::instdir}/${version}",


### PR DESCRIPTION
This to fix #7 .
This should be still compatible with previous version of puppet: [puppet doc for 3.8](https://docs.puppet.com/puppet/3.8/reference/type.html#file-attribute-mode).
